### PR TITLE
Generic transact

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ Operands:
 
 - `origin_type: OriginKind`: The means of expressing the message origin as a dispatch origin.
 - `max_weight: Weight`: The maximum amount of weight to expend while dispatching `call`. If dispatch requires more weight then an error will be thrown. If dispatch requires less weight, then Surplus Weight Register may increase.
-- `call: Vec<u8>`: The encoded transaction to be applied.
+- `call: ([u8; 32], Vec<u8)`: A well known interface identifier and the encoded body of the transaction to be applied.
+- `index: u8`: A disambiguation index in case the call can be dispatched by more than one subsystem.
 
 Kind: *Instruction*.
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Operands:
 
 - `origin_type: OriginKind`: The means of expressing the message origin as a dispatch origin.
 - `max_weight: Weight`: The maximum amount of weight to expend while dispatching `call`. If dispatch requires more weight then an error will be thrown. If dispatch requires less weight, then Surplus Weight Register may increase.
-- `call: ([u8; 32], Vec<u8)`: A well known interface identifier and the encoded body of the transaction to be applied.
+- `call: ([u8; 32], Vec<u8>)`: A well known interface identifier and the encoded body of the transaction to be applied.
 - `index: u8`: A disambiguation index in case the call can be dispatched by more than one subsystem.
 
 Kind: *Instruction*.


### PR DESCRIPTION
I figured this is a better place to continue the discussion started in https://github.com/paritytech/polkadot/issues/5119 
The idea is decouple Transact to be more generic since the current implementation of XCM expects the encoded `call` to be runtime specific, the call data is a nested enum that encodes the pallet and extrinsic index which changes from one chain to another, with https://github.com/paritytech/xcm-format/pull/22 one can query the pallet information of the remote system to avoid hard coupling among chains but to me it feels more like a not ideal workaround that introduces the extra step of first querying the chain plus the fact that pallet info is very Substrate specific, ideally we should care more about the what to execute and not its location in the other system. Does it make sense? 

So for this I propose the "interface identifier" which represents the _what_ to execute regardless of where it's defined. For convenience it doesn't have to be a community maintained registry of calls but can be deterministically and statically generated by creating a hash table that maps generated interface identifiers to the appropriate extrinsic. In the linked issue I give a better example in case it's not clear. 

Happy to know what people think of the approach :) 